### PR TITLE
feat: change task completion to be admin-only

### DIFF
--- a/render.gno
+++ b/render.gno
@@ -381,13 +381,11 @@ func organizationHandler(res *mux.ResponseWriter, req *mux.Request) {
 				}
 			}
 		}
-
-		// Organization Kanban Board
-		out += md.H3("📋 Organization Kanban Board") + "\n\n"
-		out += md.Link("View Full Kanban", realmPath+":organization/"+strconv.Itoa(org.ID)+"/kanban") + "\n\n"
-		out += renderOrganizationKanbanPreview(org)
-	}
-
+	}	
+	// Organization Kanban Board
+	out += md.H3("📋 Organization Kanban Board") + "\n\n"
+	out += md.Link("View Full Kanban", realmPath+":organization/"+strconv.Itoa(org.ID)+"/kanban") + "\n\n"
+	out += renderOrganizationKanbanPreview(org)	
 	res.Write(out)
 }
 
@@ -501,7 +499,7 @@ func tasksHandler(res *mux.ResponseWriter, req *mux.Request) {
 	if taskCount == 0 {
 		out += md.Bold("No tasks yet.") + "\n\n"
 		out += "Organizations can create tasks for their bounties.\n\n"
-		out += md.Link("Create First Task", realmPath+":task/create") + "\n\n"
+		out += md.Link("Browse Organizations", realmPath+":organizations") + " to find an organization and create tasks.\n\n"
 		res.Write(out)
 		return
 	}

--- a/tasks.gno
+++ b/tasks.gno
@@ -81,6 +81,7 @@ func CompleteTask(cur realm, taskIDStr string) {
 }
 
 // updates the kanban status of an assigned task
+// Assignee can update all statuses
 func UpdateKanbanStatus(cur realm, taskIDStr, statusIDStr string) {
 	caller := std.OriginCaller()
 
@@ -107,11 +108,27 @@ func UpdateKanbanStatus(cur realm, taskIDStr, statusIDStr string) {
 		panic("Task not found")
 	}
 
-	if task.Assignee != caller {
-		panic("Only assignee can update kanban status")
+	org := getOrganization(task.OrganizationID)
+	if org == nil {
+		panic("Organization not found")
 	}
 
-	task.KanbanStatus = KanbanStatus(statusInt)
+	// Check permissions based on status
+	isAssignee := task.Assignee == caller
+	isOrgAdmin := org.Admin == caller
+	targetStatus := KanbanStatus(statusInt)
+
+
+	if !isAssignee && !isOrgAdmin {
+		panic("Only assignee or organization admin can update kanban status")
+	}
+
+	// Organization admin can only update Review (2) and Done (3)
+	if !isAssignee && isOrgAdmin && (targetStatus != KanbanReview && targetStatus != KanbanDone) {
+		panic("Organization admin can only set Review or Done status")
+	}
+
+	task.KanbanStatus = targetStatus
 	tasks.Set(strconv.Itoa(taskID), task)
 }
 


### PR DESCRIPTION
I modified the task completion action. Because this action is reserved for the organization, as they are the ones who determine whether the user's task is acceptable to them